### PR TITLE
Show toast message if permissions are denied

### DIFF
--- a/lib/src/flutter_mono.dart
+++ b/lib/src/flutter_mono.dart
@@ -238,12 +238,17 @@ class _FlutterMonoState extends State<FlutterMono> {
     if (!isCameraGranted) {
       final result = await Permission.camera.request();
 
-      if (result == PermissionStatus.granted) {
-        await loadRequest();
+      if (result != PermissionStatus.granted) {
+        const snackBar = SnackBar(
+          content: Text('Permissions not granted'),
+        );
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(snackBar);
+        }
       }
-    } else {
-      await loadRequest();
     }
+
+    await loadRequest();
   }
 
   Future<void> loadRequest() {


### PR DESCRIPTION
This PR displays a snackbar message if the camera permissions are denied and then loads the request url.